### PR TITLE
Add compatibility with GridFieldBulkEditing

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -17,6 +17,8 @@ LeftAndMain:
   extra_requirements_javascript: ['kickassets/javascript/kickassets-cms.js']
 UploadField:
   extensions: ['KickAssetsUploadField']
+GridFieldBulkUpload_Request:
+  extensions: ['KickAssetsGridFieldBulkUpload_Request']
 ---
 Only:
   environment: dev

--- a/code/KickAssetsGridFieldBulkUpload_Request.php
+++ b/code/KickAssetsGridFieldBulkUpload_Request.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @property GridFieldBulkUpload_Request $owner
+ */
+class KickAssetsGridFieldBulkUpload_Request extends DataExtension {
+
+    private static $allowed_actions = array(
+        'folderid'
+    );
+
+    public function folderid(SS_HTTPRequest $r) {
+        return $this->owner->getUploadField()->folderid($r);
+    }
+
+}


### PR DESCRIPTION
Im not sure if KickAssets should provide compatibility with [GridFieldBulkEditing](https://github.com/colymba/GridFieldBulkEditingTools#bulk-upload) or if GridFieldBulkEditing should  provide compatibility with KickAssets...?

But here is one solution for KickAssets to provide compatibility