### PR TITLE
Added check to make sure User Agent is set.

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -3,7 +3,7 @@
 define('KICKASSETS_DIR', basename(__DIR__));
 
 // IE9 doesn't get to play with us.
-if(!preg_match('/(?i)msie [5-9]/',$_SERVER['HTTP_USER_AGENT'])) {
+if(isset($_SERVER['HTTP_USER_AGENT']) && !preg_match('/(?i)msie [5-9]/',$_SERVER['HTTP_USER_AGENT'])) {
 	CMSMenu::remove_menu_item('AssetAdmin');
 }
 else {


### PR DESCRIPTION
Currently if PHP errors are turned on and a CLI command such as the sniffer for SSPak is run, having KickAssets installed will throw a notice, which in SSPak's case can cause further problems.

My fix simply adds a check for the User Agent key before trying to use it! If you'd like me to format this more robustly, let me know.