### PR TITLE
Fix for using Translatable & UploadField From files

### DIFF
--- a/javascript/kickassets-uploadfield.js
+++ b/javascript/kickassets-uploadfield.js
@@ -8,7 +8,7 @@ $.entwine('ss', function ($) {
 				this._super();
 				var iFrameURL = this.getConfig().urlSelectDialog,
 					self = this,
-					folderURL = iFrameURL.replace(/select$/,'folderid');
+					folderURL = iFrameURL.replace(/select/,'folderid');
 
 				$.ajax({
 					url: folderURL,


### PR DESCRIPTION
If you attempt to use "From files" on an upload field with Translatable installed the regex fails due to ?Locale= being added to the URL and the following error comes up in firebug console

http://localhost/test/admin/kickassets/folder/NaN?sort=newest" 404 Not Found

I tested this with Translatable enabled, and disabled.