### PR TITLE
Display Filename if no Title

### DIFF
--- a/code/KickAssets.php
+++ b/code/KickAssets.php
@@ -543,7 +543,7 @@ class KickAssets extends LeftAndMain {
 		return array (
 			'id' => $file->ID,
 			'parentID' => $file->ParentID,
-			'title' => $file->Title,
+			'title' => ($file->Title) ? $file->Title : basename($file->Filename),
 			'filename' => basename($file->Filename),
 			'path' => $file->Filename,
 			'filesize' => $file->getAbsoluteSize(),


### PR DESCRIPTION
Hi,

I'm not sure it was intentional, but when a File does not have a Title, it doesn't display anything at all, making it difficult to browse the files. This fix displays the filename if the is no Title. Perhaps a file Title should be required instead. Or, like folder, when leaving the Title blank, it is automatically populated with the filename.

Thanks.