### PR TITLE
Change dictionary name to it for it.js and it.yml

### DIFF
--- a/lang/it.js
+++ b/lang/it.js
@@ -2,7 +2,7 @@ if(typeof(ss) == 'undefined' || typeof(ss.i18n) == 'undefined') {
 	if(typeof(console) != 'undefined') console.error('Class ss.i18n not defined');
 } 
 else {
-	ss.i18n.addDictionary('en', {
+	ss.i18n.addDictionary('it', {
 		'Kickassets.ADDFILES': 'Aggiungi files...',
 		'KickAssets.DIDNTWORK': 'Oh beh, qualcosa è andato storto.',
 		'KickAssets.FILETOOBIG': 'File troppo grande. (%sMB). Massime dimensioni: %sMB',

--- a/lang/it.yml
+++ b/lang/it.yml
@@ -1,3 +1,3 @@
-en:
+it:
   KickAssets:
     MENUTITLE: 'Sfoglia files...'


### PR DESCRIPTION
Fix a typo where italian translation files did not have the dictionary name set to "it", but instead was "en".