### PR TITLE
Revert italian translation of javascript files with correct EN namespace

### DIFF
--- a/lang/it.js
+++ b/lang/it.js
@@ -2,7 +2,7 @@ if(typeof(ss) == 'undefined' || typeof(ss.i18n) == 'undefined') {
 	if(typeof(console) != 'undefined') console.error('Class ss.i18n not defined');
 } 
 else {
-	ss.i18n.addDictionary('it', {
+	ss.i18n.addDictionary('en', {
 		'Kickassets.ADDFILES': 'Aggiungi files...',
 		'KickAssets.DIDNTWORK': 'Oh beh, qualcosa è andato storto.',
 		'KickAssets.FILETOOBIG': 'File troppo grande. (%sMB). Massime dimensioni: %sMB',


### PR DESCRIPTION
All the javascript language files of this project share the EN namespace to work correctly, so it has been reverted because it wasn't picked up by the interface.  