### PR TITLE
Added extension hook for file search

### DIFF
--- a/code/KickAssets.php
+++ b/code/KickAssets.php
@@ -402,10 +402,13 @@ class KickAssets extends LeftAndMain {
 		if($r->getVar('search') === null) return;
 
 		$results = array ();
+		$searchTerm = $r->getVar('search');
 		$list = File::get()->filterAny(array(
-			'Title:PartialMatch' => $r->getVar('search'),
-			'Filename:PartialMatch' => $r->getVar('search')
+			'Title:PartialMatch' => $searchTerm,
+			'Filename:PartialMatch' => $searchTerm
 		))->limit(100);
+		
+		$this->extend('beforeHandleSearch', $list, $searchTerm);
 		
 		foreach($list as $item) {
 			if(!$item->canView()) continue;


### PR DESCRIPTION
This allows the search to be extended e.g. your File object might have more fields to search by like "Keywords".

With this hook you can further filter the results or completely start again:
```
KickAssetsExtension.php...
public function beforeHandleSearch(&$list, $searchTerm)
{
    $list = File::get()->filterAny(array(
        'Title:PartialMatch' => $searchTerm,
	'Filename:PartialMatch' => $searchTerm,
        'Keywords:PartialMatch' => $searchTerm
    ));
}
```